### PR TITLE
[Fix] Update crop_sub_images.py

### DIFF
--- a/crop_sub_images.py
+++ b/crop_sub_images.py
@@ -157,23 +157,27 @@ def parse_args():
         '--scales', nargs='*', default=[], help='scale factor list')
     parser.add_argument(
         '--crop-size',
+        type=int,
         nargs='?',
         default=480,
         help='cropped size for HR images')
     parser.add_argument(
-        '--step', nargs='?', default=240, help='step size for HR images')
+        '--step', type=int, nargs='?', default=240, help='step size for HR images')
     parser.add_argument(
         '--thresh-size',
+        type=int,
         nargs='?',
         default=0,
         help='threshold size for HR images')
     parser.add_argument(
         '--compression-level',
+        type=int,
         nargs='?',
         default=3,
         help='compression level when save png images')
     parser.add_argument(
         '--n-thread',
+        type=int,
         nargs='?',
         default=20,
         help='thread number when using multiprocessing')


### PR DESCRIPTION
Motivation:
There are several arguments in the script crop_sub_images.py should be int type, e.g., '--n-thread'. However, if we do not define them as int. They will be regarded as str if we pass those arguments to this script by ourselves, and therefore generate an error message.

Modification:
Define the int arguments with type=int explicitly.