### PR TITLE
updated inference code for mmagic and mmcv2.0

### DIFF
--- a/updated_inference_code/README.md
+++ b/updated_inference_code/README.md
@@ -1,0 +1,13 @@
+# RealBasicVSR inference in mmcv2.0
+
+This script was edited by [me](github.com/jere357) to run basicvsr inference on mmcv2.0 + mmagic since mmediting is deprecated now and there are some slight differences in the code of basicvsr in mmcv2.0 + mmagic vs the original code in mmediting. I have also added 2 tqdm progress bars (1 for nn inference and 1 work writing the video to the disk) so you can watch them fill up while your code is running.
+
+* This code should work on your average mmcv2.0 + mmagic docker image i have also dumped the environment in the requirements.txt file so you can compare versions of packages and maybe locate the problem if you are having trouble running this code.
+
+
+I have also included the updated_builder.py file which also needed very slight changes to work with mmcv2.0 + mmagic. For now this code only works and was tested in a <ins>video --> video</ins> setting. I have not tested it with images, that case might need some slight changes as well, I have also addedd .mkv as a readable format
+
+
+* If you run into CUDA out of memory error try changing the seq_len parameter from None to something like 15
+
+* feel free to contact me here or at jeronim@aimages.ai

--- a/updated_inference_code/requirements.txt
+++ b/updated_inference_code/requirements.txt
@@ -1,0 +1,172 @@
+#this cursed requirements file is here so people can cross reference their mmcv/torch versions to the ones that worked on this code.
+#i used the dockerfile from the latest mmcv repo to start my environment(21/05/2023) the original inference_realbasicvsr.py doens't work with the latest mmcv + mmagic.
+absl-py==1.4.0
+addict==2.4.0
+asttokens @ file:///opt/conda/conda-bld/asttokens_1646925590279/work
+astunparse==1.6.3
+attrs==23.1.0
+av==10.0.0
+backcall @ file:///home/ktietz/src/ci/backcall_1611930011877/work
+beautifulsoup4 @ file:///croot/beautifulsoup4-split_1681493039619/work
+boltons @ file:///croot/boltons_1677628692245/work
+brotlipy==0.7.0
+cachetools==5.3.0
+certifi @ file:///croot/certifi_1683875369620/work/certifi
+cffi @ file:///croot/cffi_1670423208954/work
+chardet @ file:///home/builder/ci_310/chardet_1640804867535/work
+charset-normalizer @ file:///tmp/build/80754af9/charset-normalizer_1630003229654/work
+click==8.1.3
+-e git+https://github.com/openai/CLIP.git@d50d76daa670286dd6cacf3bcd80b5e4823fc8e1#egg=clip
+colorama==0.4.6
+conda==23.3.1
+conda-build==3.24.0
+conda-content-trust @ file:///tmp/abs_5952f1c8-355c-4855-ad2e-538535021ba5h26t22e5/croots/recipe/conda-content-trust_1658126371814/work
+conda-package-handling @ file:///croot/conda-package-handling_1672865015732/work
+conda_package_streaming @ file:///croot/conda-package-streaming_1670508151586/work
+contourpy==1.0.7
+controlnet-aux==0.0.3
+coverage==6.5.0
+cryptography @ file:///croot/cryptography_1677533068310/work
+cycler==0.11.0
+decorator @ file:///opt/conda/conda-bld/decorator_1643638310831/work
+diffusers==0.16.1
+dnspython==2.3.0
+einops==0.6.1
+exceptiongroup==1.1.1
+executing @ file:///opt/conda/conda-bld/executing_1646925071911/work
+expecttest==0.1.4
+face-alignment==1.3.5
+facexlib==0.3.0
+filelock @ file:///croot/filelock_1672387128942/work
+filterpy==1.4.5
+fonttools==4.39.4
+fsspec==2023.5.0
+ftfy==6.1.1
+gdown==4.7.1
+glob2 @ file:///home/linux1/recipes/ci/glob2_1610991677669/work
+gmpy2 @ file:///tmp/build/80754af9/gmpy2_1645455533097/work
+google-auth==2.18.1
+google-auth-oauthlib==1.0.0
+grpcio==1.54.2
+huggingface-hub==0.14.1
+hypothesis==6.75.2
+idna @ file:///croot/idna_1666125576474/work
+imageio==2.28.1
+imageio-ffmpeg==0.4.4
+importlib-metadata==6.6.0
+iniconfig==2.0.0
+interrogate==1.5.0
+ipython @ file:///croot/ipython_1680701871216/work
+jedi @ file:///tmp/build/80754af9/jedi_1644315229345/work
+Jinja2 @ file:///croot/jinja2_1666908132255/work
+jsonpatch @ file:///tmp/build/80754af9/jsonpatch_1615747632069/work
+jsonpointer==2.1
+kiwisolver==1.4.4
+lazy_loader==0.2
+libarchive-c @ file:///tmp/build/80754af9/python-libarchive-c_1617780486945/work
+llvmlite==0.40.0
+lmdb==1.4.1
+lpips==0.1.4
+Markdown==3.4.3
+markdown-it-py==2.2.0
+MarkupSafe @ file:///opt/conda/conda-bld/markupsafe_1654597864307/work
+matplotlib==3.7.1
+matplotlib-inline @ file:///opt/conda/conda-bld/matplotlib-inline_1662014470464/work
+mdurl==0.1.2
+mkl-fft==1.3.6
+mkl-random @ file:///work/mkl/mkl_random_1682950433854/work
+mkl-service==2.4.0
+-e git+https://github.com/open-mmlab/mmagic.git@97f8a9b7a22dea71e629ba851d9d09aa9264dae5#egg=mmagic
+mmcv==2.0.0rc1
+mmdet==3.0.0
+mmengine==0.7.3
+model-index==0.1.11
+mpmath==1.3.0
+networkx==3.1
+numba==0.57.0
+numpy @ file:///work/mkl/numpy_and_numpy_base_1682953417311/work
+oauthlib==3.2.2
+open-clip-torch==2.20.0
+opencv-python==4.7.0.72
+openmim==0.3.7
+ordered-set==4.1.0
+packaging @ file:///croot/packaging_1678965309396/work
+pandas==2.0.1
+parso @ file:///opt/conda/conda-bld/parso_1641458642106/work
+pexpect @ file:///tmp/build/80754af9/pexpect_1605563209008/work
+pickleshare @ file:///tmp/build/80754af9/pickleshare_1606932040724/work
+Pillow==9.4.0
+pkginfo @ file:///croot/pkginfo_1679431160147/work
+pluggy @ file:///tmp/build/80754af9/pluggy_1648024709248/work
+prompt-toolkit @ file:///croot/prompt-toolkit_1672387306916/work
+protobuf==3.20.3
+psutil @ file:///opt/conda/conda-bld/psutil_1656431268089/work
+ptyprocess @ file:///tmp/build/80754af9/ptyprocess_1609355006118/work/dist/ptyprocess-0.7.0-py2.py3-none-any.whl
+pure-eval @ file:///opt/conda/conda-bld/pure_eval_1646925070566/work
+py==1.11.0
+pyasn1==0.5.0
+pyasn1-modules==0.3.0
+pycocotools==2.0.6
+pycosat @ file:///croot/pycosat_1666805502580/work
+pycparser @ file:///tmp/build/80754af9/pycparser_1636541352034/work
+Pygments @ file:///croot/pygments_1683671804183/work
+pyOpenSSL @ file:///croot/pyopenssl_1677607685877/work
+pyparsing==3.0.9
+PyQt5==5.15.9
+PyQt5-Qt5==5.15.2
+PyQt5-sip==12.12.1
+PySocks @ file:///home/builder/ci_310/pysocks_1640793678128/work
+pytest==7.3.1
+python-dateutil==2.8.2
+python-etcd==0.4.5
+pytz @ file:///croot/pytz_1671697431263/work
+PyWavelets==1.4.1
+PyYAML @ file:///croot/pyyaml_1670514731622/work
+regex==2023.5.5
+requests @ file:///croot/requests_1682607517574/work
+requests-oauthlib==1.3.1
+resize-right==0.0.2
+rich==13.3.5
+rsa==4.9
+ruamel.yaml @ file:///croot/ruamel.yaml_1666304550667/work
+ruamel.yaml.clib @ file:///croot/ruamel.yaml.clib_1666302247304/work
+safetensors==0.3.1
+scikit-image==0.20.0
+scipy==1.10.1
+sentencepiece==0.1.99
+shapely==2.0.1
+six @ file:///tmp/build/80754af9/six_1644875935023/work
+sortedcontainers==2.4.0
+soupsieve @ file:///croot/soupsieve_1680518478486/work
+stack-data @ file:///opt/conda/conda-bld/stack_data_1646927590127/work
+sympy==1.12
+tabulate==0.9.0
+tensorboard==2.13.0
+tensorboard-data-server==0.7.0
+termcolor==2.3.0
+terminaltables==3.1.10
+tifffile==2023.4.12
+timm==0.9.2
+tokenizers==0.13.3
+toml==0.10.2
+tomli @ file:///opt/conda/conda-bld/tomli_1657175507142/work
+toolz @ file:///croot/toolz_1667464077321/work
+torch==2.0.1
+torchaudio==2.0.2
+torchdata @ file:///__w/_temp/conda_build_env/conda-bld/torchdata_1682362130135/work
+torchelastic==0.2.2
+torchtext==0.15.2
+torchvision==0.15.2
+tqdm @ file:///croot/tqdm_1679561862951/work
+traitlets @ file:///croot/traitlets_1671143879854/work
+transformers==4.29.2
+triton==2.0.0
+types-dataclasses==0.6.6
+typing_extensions @ file:///croot/typing_extensions_1681939499988/work
+tzdata==2023.3
+urllib3 @ file:///croot/urllib3_1680254681959/work
+wcwidth @ file:///Users/ktietz/demo/mc3/conda-bld/wcwidth_1629357192024/work
+Werkzeug==2.3.4
+yapf==0.33.0
+zipp==3.15.0
+zstandard @ file:///croot/zstandard_1677013143055/work

--- a/updated_inference_code/updated_builder.py
+++ b/updated_inference_code/updated_builder.py
@@ -1,0 +1,58 @@
+import torch.nn as nn
+from mmengine import build_from_cfg
+#from mmedit.models.registry import BACKBONES, COMPONENTS, LOSSES, MODELS
+from mmagic.registry import MODELS
+
+def build(cfg, registry, default_args=None):
+    """Build module function.
+
+    Args:
+        cfg (dict): Configuration for building modules.
+        registry (obj): ``registry`` object.
+        default_args (dict, optional): Default arguments. Defaults to None.
+    """
+    if isinstance(cfg, list):
+        modules = [
+            build_from_cfg(cfg_, registry, default_args) for cfg_ in cfg
+        ]
+        return nn.Sequential(*modules)
+
+    return build_from_cfg(cfg, registry, default_args)
+
+
+def build_backbone(cfg):
+    """Build backbone.
+
+    Args:
+        cfg (dict): Configuration for building backbone.
+    """
+    return build(cfg, BACKBONES)
+
+
+def build_component(cfg):
+    """Build component.
+
+    Args:
+        cfg (dict): Configuration for building component.
+    """
+    return build(cfg, COMPONENTS)
+
+
+def build_loss(cfg):
+    """Build loss.
+
+    Args:
+        cfg (dict): Configuration for building loss.
+    """
+    return build(cfg, LOSSES)
+
+
+def build_model(cfg, train_cfg=None, test_cfg=None):
+    """Build model.
+
+    Args:
+        cfg (dict): Configuration for building model.
+        train_cfg (dict): Training configuration. Default: None.
+        test_cfg (dict): Testing configuration. Default: None.
+    """
+    return build(cfg, MODELS, dict(train_cfg=train_cfg, test_cfg=test_cfg))

--- a/updated_inference_code/updated_inference_realbasicvsr.py
+++ b/updated_inference_code/updated_inference_realbasicvsr.py
@@ -1,0 +1,163 @@
+import argparse
+import glob
+import os
+import gc
+
+import cv2
+import mmcv
+import numpy as np
+import torch
+import torch.nn as nn
+from mmengine.runner import load_checkpoint
+from mmengine import mkdir_or_exist
+from mmcv.image.misc import tensor2imgs
+from mmengine import Config
+from tqdm import tqdm
+
+#from mmcv.ops.
+from updated_builder import build_model
+
+VIDEO_EXTENSIONS = ('.mp4', '.mov', '.mkv')
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Inference script of RealBasicVSR')
+    parser.add_argument('config', help='test config file path')
+    parser.add_argument('checkpoint', help='checkpoint file')
+    parser.add_argument('input_dir', help='directory of the input video')
+    parser.add_argument('output_dir', help='directory of the output video')
+    parser.add_argument(
+        '--max_seq_len',
+        type=int,
+        default=15,
+        help='maximum sequence length to be processed')
+    parser.add_argument(
+        '--is_save_as_png',
+        type=bool,
+        default=True,
+        help='whether to save as png')
+    parser.add_argument(
+        '--fps', type=float, default=25, help='FPS of the output video')
+    args = parser.parse_args()
+
+    return args
+
+
+def init_model(config, checkpoint=None):
+    """Initialize a model from config file.
+
+    Args:
+        config (str or :obj:`mmcv.Config`): Config file path or the config
+            object.
+        checkpoint (str, optional): Checkpoint path. If left as None, the model
+            will not load any weights.
+        device (str): Which device the model will deploy. Default: 'cuda:0'.
+
+    Returns:
+        nn.Module: The constructed model.
+    """
+
+    if isinstance(config, str):
+        config = Config.fromfile(config)
+    elif not isinstance(config, Config):
+        raise TypeError('config must be a filename or Config object, '
+                        f'but got {type(config)}')
+    #config.model.pretrained = None
+    #config.test_cfg.metrics = None
+    model = build_model(config.model, test_cfg=config.test_cfg)
+    if checkpoint is not None:
+        checkpoint = load_checkpoint(model, checkpoint)
+
+    #model.cfg = config  # save the config in the model for convenience
+    model.eval()
+
+    return model
+
+def init_model2(config, checkpoint=None):
+    model = None
+    return model
+
+def main():
+    args = parse_args()
+
+    # initialize the model
+    model = init_model(args.config, args.checkpoint)
+
+    # read images
+    file_extension = os.path.splitext(args.input_dir)[1]
+    
+    if file_extension in VIDEO_EXTENSIONS:  # input is a video file
+        video_reader = mmcv.VideoReader(args.input_dir)
+        inputs = []
+        for frame in video_reader:
+            inputs.append(np.flip(frame, axis=2))
+    elif file_extension == '':  # input is a directory
+        inputs = []
+        input_paths = sorted(glob.glob(f'{args.input_dir}/*'))
+        for input_path in input_paths:
+            img = mmcv.imread(input_path, channel_order='rgb')
+            inputs.append(img)
+    else:
+        raise ValueError('"input_dir" can only be a video or a directory.')
+
+    for i, img in enumerate(inputs):
+        img = torch.from_numpy(img / 255.).permute(2, 0, 1).float()
+        inputs[i] = img.unsqueeze(0)
+    inputs = torch.stack(inputs, dim=1)
+
+    # map to cuda, if available
+    cuda_flag = False
+    if torch.cuda.is_available():
+        model = model.cuda()
+        cuda_flag = True
+
+    with torch.no_grad():
+        if isinstance(args.max_seq_len, int):
+            outputs = []
+            for i in tqdm(range(0, inputs.size(1), args.max_seq_len)):
+                imgs = inputs[:, i:i + args.max_seq_len, :, :, :]
+                if cuda_flag:
+                    imgs = imgs.cuda()
+                #output1 = model(imgs)
+                outputs.append(model(imgs).cpu())
+            outputs = torch.cat(outputs, dim=1)
+        else:
+            if cuda_flag:
+                #inputs.to(dtype=torch.float16)
+                #inputs = inputs.squeeze()
+                inputs = inputs.cuda()
+            outputs = model(inputs)['output'].cpu()
+    del model
+    torch.cuda.empty_cache() 
+    gc.collect()
+    if os.path.splitext(args.output_dir)[1] in VIDEO_EXTENSIONS:
+        output_dir = os.path.dirname(args.output_dir)
+        mkdir_or_exist(output_dir)
+
+        h, w = outputs.shape[-2:]
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+        video_writer = cv2.VideoWriter(args.output_dir, fourcc, args.fps,
+                                       (w, h))
+        for i in tqdm(range(0, outputs.size(1))):
+            #img = tensor2imgs(outputs[:, i, :, :, :])[0]
+            #the new version of tensor2imgs doesnt multiply the outputs by 255 so it needs 
+            #to be done here, i don't think it causes any unwanted side effects
+            img = tensor2imgs(outputs[:, i, :, :, :]*255)[0]
+            video_writer.write(img)
+
+        cv2.destroyAllWindows()
+        video_writer.release()
+    else:
+        mkdir_or_exist(args.output_dir)
+        for i in range(0, outputs.size(1)):
+            output = tensor2imgs(outputs[:, i, :, :, :])
+            filename = os.path.basename(input_paths[i])
+            if args.is_save_as_png:
+                file_extension = os.path.splitext(filename)[1]
+                filename = filename.replace(file_extension, '.png')
+            mmcv.imwrite(output, f'{args.output_dir}/{filename}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Nothing too complicated, updated inference code to work out of the box for mmagic + mmcv2.0 since the MMinferencer from mmagic wasn't really working as intended out of the box. I leave it to the author to edit the orignal readme.md file and mention this folder or something. 

Most of the changes are very slight differences in code due to mmcv2.0. As things are now the user can position themselves in the updated_inference_code folder and run the same inference script and things should work* on mmcv2.0